### PR TITLE
Switch from custom oracle updater to foojay updater

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -1,117 +1,130 @@
 github:
   username: ${{ secrets.JAVA_GITHUB_USERNAME }}
-  token:    ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+  token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
 helpers:
   "bin/helper": "github.com/paketo-buildpacks/libjvm/cmd/helper"
 
 codeowners:
-- path:  "*"
-  owner: "@paketo-buildpacks/java-maintainers"
+  - path: "*"
+    owner: "@paketo-buildpacks/java-maintainers"
 
 package:
-  repositories:   ["docker.io/paketobuildpacks/oracle","gcr.io/paketo-buildpacks/oracle"]
-  register:       true
+  repositories:
+    ["docker.io/paketobuildpacks/oracle", "gcr.io/paketo-buildpacks/oracle"]
+  register: true
   registry_token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
 docker_credentials:
-- registry: gcr.io
-  username: _json_key
-  password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
-- registry: docker.io
-  username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
-  password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
+  - registry: gcr.io
+    username: _json_key
+    password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+  - registry: docker.io
+    username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
+    password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
 
 dependencies:
-- name:            JDK 17
-  id:              jdk
-  version_pattern: "17\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: jdk
-    version: "17"
-- name:            JDK 21
-  id:              jdk
-  version_pattern: "21\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: jdk
-    version: "21"
-- name:            JDK 22
-  id:              jdk
-  version_pattern: "22\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: jdk
-    version: "22"
-- name:            Native Image 17
-  id:              native-image-svm
-  version_pattern: "17\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: graalvm
-    version: "17"
-- name:            Native Image 21
-  id:              native-image-svm
-  version_pattern: "21\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: graalvm
-    version: "21"
-- name:            Native Image 22
-  id:              native-image-svm
-  version_pattern: "22\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: graalvm
-    version: "22"
+  - name: JDK 17
+    id: jdk
+    version_pattern: "17\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: jdk
+      version: "17"
+      distro: oracle
+  - name: JDK 21
+    id: jdk
+    version_pattern: "21\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: jdk
+      version: "21"
+      distro: oracle
+  - name: JDK 22
+    id: jdk
+    version_pattern: "22\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: jdk
+      version: "22"
+      distro: oracle
+  - name: Native Image 17
+    id: native-image-svm
+    version_pattern: "17\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: graalvm
+      version: "17"
+      distro: oracle
+  - name: Native Image 21
+    id: native-image-svm
+    version_pattern: "21\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: graalvm
+      version: "21"
+      distro: oracle
+  - name: Native Image 22
+    id: native-image-svm
+    version_pattern: "22\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: graalvm
+      version: "22"
+      distro: oracle
 
-# ARM64
-- name:            JDK 17 ARM64
-  id:              jdk
-  version_pattern: "17\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: jdk
-    version: "17"
-    arch: "arm64"
-- name:            JDK 21 ARM64
-  id:              jdk
-  version_pattern: "21\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: jdk
-    version: "21"
-    arch: "arm64"
-- name:            JDK 22 ARM64
-  id:              jdk
-  version_pattern: "22\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: jdk
-    version: "22"
-    arch: "arm64"
-- name:            Native Image 17 ARM64
-  id:              native-image-svm
-  version_pattern: "17\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: graalvm
-    version: "17"
-    arch: "arm64"
-- name:            Native Image 21 ARM64
-  id:              native-image-svm
-  version_pattern: "21\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: graalvm
-    version: "21"
-    arch: "arm64"
-- name:            Native Image 22 ARM64
-  id:              native-image-svm
-  version_pattern: "22\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
-  with:
-    type: graalvm
-    version: "22"
-    arch: "arm64"
+  # ARM64
+  - name: JDK 17 ARM64
+    id: jdk
+    version_pattern: "17\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: jdk
+      version: "17"
+      distro: oracle
+      arch: "arm64"
+  - name: JDK 21 ARM64
+    id: jdk
+    version_pattern: "21\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: jdk
+      version: "21"
+      distro: oracle
+      arch: "arm64"
+  - name: JDK 22 ARM64
+    id: jdk
+    version_pattern: "22\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: jdk
+      version: "22"
+      distro: oracle
+      arch: "arm64"
+  - name: Native Image 17 ARM64
+    id: native-image-svm
+    version_pattern: "17\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: graalvm
+      version: "17"
+      distro: oracle
+      arch: "arm64"
+  - name: Native Image 21 ARM64
+    id: native-image-svm
+    version_pattern: "21\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: graalvm
+      version: "21"
+      distro: oracle
+      arch: "arm64"
+  - name: Native Image 22 ARM64
+    id: native-image-svm
+    version_pattern: "22\\.[\\d]+\\.[\\d]+"
+    uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
+    with:
+      type: graalvm
+      version: "22"
+      distro: oracle
+      arch: "arm64"

--- a/.github/workflows/pb-update-jdk-17-arm-64.yml
+++ b/.github/workflows/pb-update-jdk-17-arm-64.yml
@@ -25,9 +25,10 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
                 arch: arm64
+                distro: oracle
                 type: jdk
                 version: "17"
             - name: Update Buildpack Dependency

--- a/.github/workflows/pb-update-jdk-17.yml
+++ b/.github/workflows/pb-update-jdk-17.yml
@@ -25,8 +25,9 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
+                distro: oracle
                 type: jdk
                 version: "17"
             - name: Update Buildpack Dependency

--- a/.github/workflows/pb-update-jdk-21-arm-64.yml
+++ b/.github/workflows/pb-update-jdk-21-arm-64.yml
@@ -25,9 +25,10 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
                 arch: arm64
+                distro: oracle
                 type: jdk
                 version: "21"
             - name: Update Buildpack Dependency

--- a/.github/workflows/pb-update-jdk-21.yml
+++ b/.github/workflows/pb-update-jdk-21.yml
@@ -25,8 +25,9 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
+                distro: oracle
                 type: jdk
                 version: "21"
             - name: Update Buildpack Dependency

--- a/.github/workflows/pb-update-jdk-22-arm-64.yml
+++ b/.github/workflows/pb-update-jdk-22-arm-64.yml
@@ -25,9 +25,10 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
                 arch: arm64
+                distro: oracle
                 type: jdk
                 version: "22"
             - name: Update Buildpack Dependency

--- a/.github/workflows/pb-update-jdk-22.yml
+++ b/.github/workflows/pb-update-jdk-22.yml
@@ -25,8 +25,9 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
+                distro: oracle
                 type: jdk
                 version: "22"
             - name: Update Buildpack Dependency

--- a/.github/workflows/pb-update-native-image-17-arm-64.yml
+++ b/.github/workflows/pb-update-native-image-17-arm-64.yml
@@ -25,9 +25,10 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
                 arch: arm64
+                distro: oracle
                 type: graalvm
                 version: "17"
             - name: Update Buildpack Dependency

--- a/.github/workflows/pb-update-native-image-17.yml
+++ b/.github/workflows/pb-update-native-image-17.yml
@@ -25,8 +25,9 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
+                distro: oracle
                 type: graalvm
                 version: "17"
             - name: Update Buildpack Dependency

--- a/.github/workflows/pb-update-native-image-21-arm-64.yml
+++ b/.github/workflows/pb-update-native-image-21-arm-64.yml
@@ -25,9 +25,10 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
                 arch: arm64
+                distro: oracle
                 type: graalvm
                 version: "21"
             - name: Update Buildpack Dependency

--- a/.github/workflows/pb-update-native-image-21.yml
+++ b/.github/workflows/pb-update-native-image-21.yml
@@ -25,8 +25,9 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
+                distro: oracle
                 type: graalvm
                 version: "21"
             - name: Update Buildpack Dependency

--- a/.github/workflows/pb-update-native-image-22-arm-64.yml
+++ b/.github/workflows/pb-update-native-image-22-arm-64.yml
@@ -25,9 +25,10 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
                 arch: arm64
+                distro: oracle
                 type: graalvm
                 version: "22"
             - name: Update Buildpack Dependency

--- a/.github/workflows/pb-update-native-image-22.yml
+++ b/.github/workflows/pb-update-native-image-22.yml
@@ -25,8 +25,9 @@ jobs:
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency
-              uses: docker://ghcr.io/paketo-buildpacks/actions/oracle-dependency:main
+              uses: docker://ghcr.io/paketo-buildpacks/actions/foojay-dependency:main
               with:
+                distro: oracle
                 type: graalvm
                 version: "22"
             - name: Update Buildpack Dependency


### PR DESCRIPTION
## Summary
The custom Oracle updater is scraping HTML from a website. It is brittle. The HTML has changed again and broke updates. Using Foojay updater, there is an actual API so things will be more stable.

## Use Cases
More stable updates

