### PR TITLE
Change default BP_JVM_VERSION from 17 to 21

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -123,7 +123,7 @@ api = "0.7"
 
   [[metadata.configurations]]
     build = true
-    default = "17"
+    default = "21"
     description = "the Java version"
     name = "BP_JVM_VERSION"
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Change the default java version from `17` to `21` (see [RFC 14](https://github.com/paketo-buildpacks/rfcs/blob/main/text/java/0014-selecting-default-java-version.md))

## Use Cases
<!-- An explanation of the use cases your change enables -->

n/a

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).

